### PR TITLE
Add missing pydantic-settings dependency to requirements.txt

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,7 @@ fastapi==0.104.1
 uvicorn==0.24.0
 aiohttp==3.9.0
 pydantic==2.5.0
+pydantic-settings==2.1.0
 sqlalchemy==2.0.23
 anthropic==0.31.2
 redis==5.0.1


### PR DESCRIPTION
## Description

This pull request adds the missing `pydantic-settings==2.1.0` dependency to the backend requirements.txt file. This dependency is essential for Railway deployment as it enables proper configuration management for the FastAPI backend application. The change is part of a larger effort to fix Railway deployment issues and enable full backend deployment with all 36 routers and personality assessment functionality.

## Test

N/A

## Changes that Break Backward Compatibility

N/A

## Documentation

N/A

*Created with [Palmier](https://www.palmier.io)*