### PR TITLE
Migrate from deprecated pinecone-client to modern pinecone package

### DIFF
--- a/backend/app/services/EmbeddingEsco_evaluation.py
+++ b/backend/app/services/EmbeddingEsco_evaluation.py
@@ -2,7 +2,6 @@ import streamlit as st
 import numpy as np
 import pandas as pd
 from scipy.spatial.distance import cosine
-import pinecone
 import psycopg2
 import json
 from sklearn.decomposition import PCA

--- a/backend/app/services/Swipe_career_recommendation_service.py
+++ b/backend/app/services/Swipe_career_recommendation_service.py
@@ -8,7 +8,7 @@ import pickle
 import random
 import json
 from app.services.Oasisembedding_service import parse_embedding, get_user_oasis_embedding
-import pinecone
+from pinecone import Pinecone
 import re
 from app.models.user_profile import UserProfile
 import ast
@@ -362,7 +362,7 @@ def get_pinecone_career_recommendations(embedding: List[float], limit: int = 30)
         logger.info(f"Initializing Pinecone with environment: {pinecone_environment}")
         
         # Initialize Pinecone client
-        pc = pinecone.Pinecone(
+        pc = Pinecone(
             api_key=pinecone_api_key,
             environment=pinecone_environment
         )

--- a/backend/app/services/occupationTree.py
+++ b/backend/app/services/occupationTree.py
@@ -4,7 +4,6 @@ import numpy as np
 from typing import List, Dict, Any, Optional
 from sqlalchemy.orm import Session
 from sqlalchemy import text
-import pinecone
 from pinecone import Pinecone
 
 # Configure logger

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -26,7 +26,7 @@ anthropic==0.31.2
 openai==1.3.0
 
 # Vector databases and search
-pinecone-client==2.2.4
+pinecone>=3.0.0
 redis==5.0.1
 
 # Data science and ML


### PR DESCRIPTION
- Updated requirements.txt from pinecone-client==2.2.4 to pinecone>=3.0.0
- Cleaned up duplicate import statements in EmbeddingEsco_evaluation.py and occupationTree.py
- Updated API usage from pinecone.Pinecone() to Pinecone() in Swipe_career_recommendation_service.py
- Verified all pinecone usage across the codebase follows modern API patterns
- Removed deprecated package references and standardized on new pinecone package

🤖 Generated with [Claude Code](https://claude.ai/code)